### PR TITLE
Installed Percona server 5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,15 @@ COPY configs/php5-fpm/www.conf /etc/php5/fpm/pool.d/www.conf
 COPY configs/nginx/default /etc/nginx/sites-available/default
 COPY configs/php5-fpm/xdebug.ini /etc/php5/mods-available/xdebug.ini
 
-#MySQL install + password
+#Install Percona Mysql 5.6 server
+RUN wget https://repo.percona.com/apt/percona-release_0.1-3.$(lsb_release -sc)_all.deb
+RUN dpkg -i percona-release_0.1-3.$(lsb_release -sc)_all.deb
+RUN rm percona-release_0.1-3.$(lsb_release -sc)_all.deb
+RUN apt-get update
 RUN echo "mysql-server mysql-server/root_password password root" | debconf-set-selections
 RUN echo "mysql-server mysql-server/root_password_again password root" | debconf-set-selections
-RUN sudo apt-get  install -y mysql-server mysql-client
+RUN apt-get install -y percona-server-server-5.6
+COPY configs/mysql/my.cnf /etc/mysql/my.cnf
 
 # SSH service
 RUN sudo apt-get install -y openssh-server openssh-client

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ RUN wget https://repo.percona.com/apt/percona-release_0.1-3.$(lsb_release -sc)_a
 RUN dpkg -i percona-release_0.1-3.$(lsb_release -sc)_all.deb
 RUN rm percona-release_0.1-3.$(lsb_release -sc)_all.deb
 RUN apt-get update
-RUN echo "mysql-server mysql-server/root_password password root" | debconf-set-selections
-RUN echo "mysql-server mysql-server/root_password_again password root" | debconf-set-selections
+RUN echo "percona-server-server-5.6 percona-server-server/root_password password root" | sudo debconf-set-selections
+RUN echo "percona-server-server-5.6 percona-server-server/root_password_again password root" | sudo debconf-set-selections
 RUN apt-get install -y percona-server-server-5.6
 COPY configs/mysql/my.cnf /etc/mysql/my.cnf
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 docker run -i -t -d --name=symfony2 -h=symfony2 -p 1080:80 -p 1022:22 -p 9001:9000 cristo/symfony2 /bin/bash
 ```
 
-#MySQL
+# Percona MySQL 5.6
 ```
 user: root 
 password: root

--- a/configs/mysql/my.cnf
+++ b/configs/mysql/my.cnf
@@ -1,0 +1,48 @@
+[client]
+port		= 3306
+socket		= /var/run/mysqld/mysqld.sock
+
+[mysqld_safe]
+socket		= /var/run/mysqld/mysqld.sock
+nice		= 0
+syslog
+
+[mysqld]
+character_set_client=utf8
+character_set_server=utf8
+
+user		= mysql
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+port		= 3306
+basedir		= /usr
+datadir		= /var/lib/mysql
+tmpdir		= /tmp
+lc-messages-dir	= /usr/share/mysql
+skip-external-locking
+
+bind-address		= 127.0.0.1
+
+key_buffer		= 16M
+max_allowed_packet	= 16M
+thread_stack		= 192K
+thread_cache_size       = 8
+myisam-recover         = BACKUP
+
+query_cache_limit	= 1M
+query_cache_size        = 16M
+
+log_error = /var/log/mysql/error.log
+
+expire_logs_days	= 10
+max_binlog_size         = 100M
+
+[mysqldump]
+quick
+quote-names
+max_allowed_packet	= 16M
+
+[mysql]
+[isamchk]
+key_buffer		= 16M
+!includedir /etc/mysql/conf.d/


### PR DESCRIPTION
With InnoDB features, like:  XtraDB

```
Percona XtraDB is an enhanced version of the InnoDB storage engine for MySQL® and MariaDB®. With more features, faster performance and better scalability on modern hardware, Percona XtraDB uses memory more efficiently, providing convenience and usability, particularly in high-load environments. It is backwards compatible with InnoDB, so you can use it as a drop-in replacement. Percona XtraDB also includes InnoDB's reliable ACID-compliant design and advanced MVCC architecture.
```
